### PR TITLE
Minor Fixes for 1.0 Release

### DIFF
--- a/.github/workflows/dotnet-blueair.cli.yml
+++ b/.github/workflows/dotnet-blueair.cli.yml
@@ -28,8 +28,45 @@ jobs:
       run: dotnet build --no-restore ./BlueAir.CLI/BlueAir.CLI.csproj
     - name: Test
       run: dotnet test --no-build --verbosity normal ./BlueAir.CLI/BlueAir.CLI.csproj
-    - name: Upload Artifact
+    - name: Publish (Windows x86_64)
+      run: dotnet publish -c Release --self-contained -r win-x64 -o ./publish/cli/win-x64/ ./BlueAir.CLI/BlueAir.CLI.csproj
+    - name: Publish (Windows ARM64)
+      run: dotnet publish -c Release --self-contained -r win-arm64 -o ./publish/cli/win-arm64/ ./BlueAir.CLI/BlueAir.CLI.csproj
+    - name: Publish (Linux x86_64)
+      run: dotnet publish -c Release --self-contained -r linux-x64 -o ./publish/cli/linux-x64/ ./BlueAir.CLI/BlueAir.CLI.csproj
+    - name: Publish (Linux ARM64)
+      run: dotnet publish -c Release --self-contained -r linux-arm64 -o ./publish/cli/linux-arm64/ ./BlueAir.CLI/BlueAir.CLI.csproj
+    - name: Publish (macOS x86_64)
+      run: dotnet publish -c Release --self-contained -r osx-x64 -o ./publish/cli/osx-x64/ ./BlueAir.CLI/BlueAir.CLI.csproj
+    - name: Publish (macOS ARM64)
+      run: dotnet publish -c Release --self-contained -r osx-arm64 -o ./publish/cli/osx-arm64/ ./BlueAir.CLI/BlueAir.CLI.csproj
+    - name: Upload Artifact (Windows x86_64)
       uses: actions/upload-artifact@v3
       with:
-          name: BlueAir CLI
-          path: ./BlueAir.CLI/bin/
+          name: BlueAir CLI (Windows x64)
+          path: ./publish/cli/win-x64/
+    - name: Upload Artifact (Windows ARM64)
+      uses: actions/upload-artifact@v3
+      with:
+          name: BlueAir CLI (Windows ARM64)
+          path: ./publish/cli/win-arm64/
+    - name: Upload Artifact (Linux x86_64)
+      uses: actions/upload-artifact@v3
+      with:
+          name: BlueAir CLI (Linux x64)
+          path: ./publish/cli/linux-x64/
+    - name: Upload Artifact (Linux ARM64)
+      uses: actions/upload-artifact@v3
+      with:
+          name: BlueAir CLI (Linux ARM64)
+          path: ./publish/cli/linux-arm64/
+    - name: Upload Artifact (macOS x86_64)
+      uses: actions/upload-artifact@v3
+      with:
+          name: BlueAir CLI (macOS x64)
+          path: ./publish/cli/osx-x64/
+    - name: Upload Artifact (macOS ARM64)
+      uses: actions/upload-artifact@v3
+      with:
+          name: BlueAir CLI (macOS ARM64)
+          path: ./publish/cli/osx-arm64/

--- a/BlueAir.Android/BlueAir.Android.csproj
+++ b/BlueAir.Android/BlueAir.Android.csproj
@@ -7,8 +7,9 @@
         <ApplicationId>com.haltroy.blueair</ApplicationId>
         <ApplicationVersion>1</ApplicationVersion>
         <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
+        <Version>1.0.0.0</Version>
+        <FileVersion>1.0.0.0</FileVersion>
         <AndroidPackageFormat>apk</AndroidPackageFormat>
-        <AndroidEnableProfiledAot>False</AndroidEnableProfiledAot>
         <Company>haltroy</Company>
         <Product>BlueAir</Product>
         <RootNamespace>BlueAir.Android</RootNamespace>

--- a/BlueAir.CLI/BlueAir.CLI.csproj
+++ b/BlueAir.CLI/BlueAir.CLI.csproj
@@ -6,6 +6,8 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>BlueAir.CLI</RootNamespace>
+        <Version>1.0.0.0</Version>
+        <FileVersion>1.0.0.0</FileVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/BlueAir.CLI/BlueAir.CLI.csproj
+++ b/BlueAir.CLI/BlueAir.CLI.csproj
@@ -8,6 +8,9 @@
         <RootNamespace>BlueAir.CLI</RootNamespace>
         <Version>1.0.0.0</Version>
         <FileVersion>1.0.0.0</FileVersion>
+        <DebugType>embedded</DebugType>
+        <PublishTrimmed>true</PublishTrimmed>
+        <PublishSingleFile>true</PublishSingleFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/BlueAir.CLI/Program.cs
+++ b/BlueAir.CLI/Program.cs
@@ -155,10 +155,7 @@ public static class Program
                    Assembly.GetExecutingAssembly() is { } ass
                    && ass.GetName() is { } name
                    && name.Version != null
-                       ? "" + (name.Version.Major > 0 ? name.Version.Major : "") +
-                         (name.Version.Minor > 0 ? "." + name.Version.Minor : "") +
-                         (name.Version.Build > 0 ? "." + name.Version.Build : "") +
-                         (name.Version.Revision > 0 ? "." + name.Version.Revision : "")
+                       ? name.Version.ToString()
                        : "?"
                );
     }

--- a/BlueAir.Desktop/BlueAir.Desktop.csproj
+++ b/BlueAir.Desktop/BlueAir.Desktop.csproj
@@ -14,6 +14,8 @@
         <Nullable>enable</Nullable>
         <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
         <RootNamespace>BlueAir.Desktop</RootNamespace>
+        <Version>1.0.0.0</Version>
+        <FileVersion>1.0.0.0</FileVersion>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/BlueAir.Standard/BlueAir.Standard.csproj
+++ b/BlueAir.Standard/BlueAir.Standard.csproj
@@ -5,6 +5,8 @@
         <Nullable>disable</Nullable>
         <RootNamespace>BlueAir</RootNamespace>
         <DebugType>embedded</DebugType>
+        <Version>1.0.0.0</Version>
+        <FileVersion>1.0.0.0</FileVersion>
     </PropertyGroup>
 
 </Project>

--- a/BlueAir.Standard/BlueAir.cs
+++ b/BlueAir.Standard/BlueAir.cs
@@ -96,6 +96,7 @@ namespace BlueAir
             CustomFolders = folders.ToArray();
 
             var agents = new List<DownloadAgent>();
+            agents.AddRange(DefaultAgents);
 
             if (Directory.Exists(SystemAgentsPath))
             {
@@ -149,15 +150,19 @@ namespace BlueAir
                         $"<CustomEnv ID=\"{(int)env_var.SpecialFolder}\" Value=\"{env_var.NewPath}\" />{Environment.NewLine}";
             xml += $"</CustomEnvironments>{Environment.NewLine}";
 
-            xml += $"<Settings>{Environment.NewLine}";
+            if (CustomSettings != null)
+            {
+                xml += $"<Settings>{Environment.NewLine}";
+                foreach (var settings in CustomSettings)
+                    xml += $"<Setting Name=\"{settings.Name}\" Value=\"{settings.Value}\" />{Environment.NewLine}";
+                xml += $"</Settings>{Environment.NewLine}";
+            }
 
-            foreach (var settings in CustomSettings)
-                xml += $"<Setting Name=\"{settings.Name}\" Value=\"{settings.Value}\" />{Environment.NewLine}";
+            xml += "</root>";
 
-            xml += $"</Settings>{Environment.NewLine}</root>";
-
+            if (!Directory.Exists(UserRootPath)) Directory.CreateDirectory(UserRootPath);
             using (var stream = new FileStream(UserSettingsPath,
-                       File.Exists(UserSettingsPath) ? FileMode.Create : FileMode.Truncate, FileAccess.Write,
+                       !File.Exists(UserSettingsPath) ? FileMode.Create : FileMode.Truncate, FileAccess.Write,
                        FileShare.ReadWrite))
             {
                 using (var writer = new StreamWriter(stream, Encoding.UTF8))

--- a/BlueAir/BlueAir.csproj
+++ b/BlueAir/BlueAir.csproj
@@ -7,6 +7,8 @@
         <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
         <RootNamespace>BlueAir</RootNamespace>
+        <Version>1.0.0.0</Version>
+        <FileVersion>1.0.0.0</FileVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/BlueAir/Properties/Resources.Designer.cs
+++ b/BlueAir/Properties/Resources.Designer.cs
@@ -314,5 +314,23 @@ namespace BlueAir.Properties {
                 return ResourceManager.GetString("AgentFileDesc", resourceCulture);
             }
         }
+        
+        public static string Main {
+            get {
+                return ResourceManager.GetString("Main", resourceCulture);
+            }
+        }
+        
+        public static string FilesAndFolders {
+            get {
+                return ResourceManager.GetString("FilesAndFolders", resourceCulture);
+            }
+        }
+        
+        public static string Commands {
+            get {
+                return ResourceManager.GetString("Commands", resourceCulture);
+            }
+        }
     }
 }

--- a/BlueAir/Properties/Resources.af.resx
+++ b/BlueAir/Properties/Resources.af.resx
@@ -158,4 +158,14 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} aflaai agent</value>
 </data>
+
+<data name="Main" xml:space="preserve">
+    <value>Vernaamste</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Lêers en gidse</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Opdragte</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.am.resx
+++ b/BlueAir/Properties/Resources.am.resx
@@ -158,4 +158,14 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{መተግበሪያ_ ስም}} ማውረድ ወኪል</value>
 </data>
+
+<data name="Main" xml:space="preserve">
+    <value>ዋና</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>ፋይሎች እና አቃፊዎች</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>ትዕዛዞች</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.ar.resx
+++ b/BlueAir/Properties/Resources.ar.resx
@@ -158,4 +158,14 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{app_name} وكيل التنزيل</value>
 </data>
+
+<data name="Main" xml:space="preserve">
+    <value>رئيسي</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>الملفات والمجلدات</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>الأوامر</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.az.resx
+++ b/BlueAir/Properties/Resources.az.resx
@@ -158,4 +158,14 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} Yükləmə agenti</value>
 </data>
+
+<data name="Main" xml:space="preserve">
+    <value>Əsas</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Fayl və qovluqlar</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Əmr</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.be.resx
+++ b/BlueAir/Properties/Resources.be.resx
@@ -158,4 +158,14 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_Name} Загрузка агента</value>
 </data>
+
+<data name="Main" xml:space="preserve">
+    <value>Галоўны</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Файлы і папкі</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Каманды</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.bg.resx
+++ b/BlueAir/Properties/Resources.bg.resx
@@ -158,4 +158,14 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} Изтегляне на агент</value>
 </data>
+
+<data name="Main" xml:space="preserve">
+    <value>Основен</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Файлове и папки</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Команди</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.bn.resx
+++ b/BlueAir/Properties/Resources.bn.resx
@@ -158,4 +158,14 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{অ্যাপ_নাম} ডাউনলোড এজেন্ট</value>
 </data>
+
+<data name="Main" xml:space="preserve">
+    <value>প্রধান</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>ফাইল এবং ফোল্ডার</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>কমান্ড</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.bs.resx
+++ b/BlueAir/Properties/Resources.bs.resx
@@ -158,4 +158,14 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} Preuzmi agent</value>
 </data>
+
+<data name="Main" xml:space="preserve">
+    <value>Glavni</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Datoteke i mape</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Naredbe</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.ca.resx
+++ b/BlueAir/Properties/Resources.ca.resx
@@ -158,4 +158,14 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} agent de descàrrega</value>
 </data>
+
+<data name="Main" xml:space="preserve">
+    <value>Principal</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Fitxers i carpetes</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Ordres</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.ceb.resx
+++ b/BlueAir/Properties/Resources.ceb.resx
@@ -158,4 +158,14 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} I-download Agent</value>
 </data>
+
+<data name="Main" xml:space="preserve">
+    <value>Labing mahinungdanon</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Mga Files ug Folder</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Mga sugo</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.co-FR.resx
+++ b/BlueAir/Properties/Resources.co-FR.resx
@@ -158,4 +158,14 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} agente di scaricamentu</value>
 </data>
+
+<data name="Main" xml:space="preserve">
+    <value>MATIN</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>File è Folders</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Cumandamenti</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.cs.resx
+++ b/BlueAir/Properties/Resources.cs.resx
@@ -158,4 +158,14 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} agent stahování</value>
 </data>
+
+<data name="Main" xml:space="preserve">
+    <value>Hlavní</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Soubory a složky</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Příkazy</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.cy.resx
+++ b/BlueAir/Properties/Resources.cy.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} asiant lawrlwytho</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Main</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Ffeiliau a Ffolderau</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Gorchmynion</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.da.resx
+++ b/BlueAir/Properties/Resources.da.resx
@@ -158,4 +158,14 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} downloadagent</value>
 </data>
+
+<data name="Main" xml:space="preserve">
+    <value>Hoved</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Filer og mapper</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Kommandoer</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.de.resx
+++ b/BlueAir/Properties/Resources.de.resx
@@ -158,4 +158,14 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} Download Agent</value>
 </data>
+
+<data name="Main" xml:space="preserve">
+    <value>Hauptsächlich</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Daten und Ordner</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Befehle</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.el.resx
+++ b/BlueAir/Properties/Resources.el.resx
@@ -158,4 +158,14 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} Λήψη πράκτορα</value>
 </data>
+
+<data name="Main" xml:space="preserve">
+    <value>Κύριος</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Αρχεία και φακέλους</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Εντολές</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.eo.resx
+++ b/BlueAir/Properties/Resources.eo.resx
@@ -158,4 +158,14 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} elŝuta agento</value>
 </data>
+
+<data name="Main" xml:space="preserve">
+    <value>Ĉefa</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Dosieroj kaj dosierujoj</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Komandoj</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.es.resx
+++ b/BlueAir/Properties/Resources.es.resx
@@ -161,4 +161,13 @@
          <value>{App_name} Agente de descarga</value>
      </data>
 
+<data name="Main" xml:space="preserve">
+    <value>Principal</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Archivos y carpetas</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Comandos</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.et.resx
+++ b/BlueAir/Properties/Resources.et.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} allalaadimisagent</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Peamine</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Failid ja kaustad</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Käsud</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.eu.resx
+++ b/BlueAir/Properties/Resources.eu.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} deskargatu agentea</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Nagusi</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Fitxategiak eta karpetak</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Aginduak</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.fa.resx
+++ b/BlueAir/Properties/Resources.fa.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{app_name} عامل دانلود</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>اصلی</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>پرونده ها و پوشه ها</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>دستورات</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.fi.resx
+++ b/BlueAir/Properties/Resources.fi.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_Name} Lataa agentti</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Pää-</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Tiedostot ja kansiot</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Komennot</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.fil.resx
+++ b/BlueAir/Properties/Resources.fil.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{APP_NAME} I -download ang ahente</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Pangunahing</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Mga file at folder</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Utos</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.fr-ht.resx
+++ b/BlueAir/Properties/Resources.fr-ht.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} download ajan</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Prensipal</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Dosye ak dosye</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Kòmandman</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.fr.resx
+++ b/BlueAir/Properties/Resources.fr.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} Agent de téléchargement</value>
 </data>
+<data name="Main" xml:space="preserve">
+         <value>Principal</value>
+     </data>
+     <data name="FilesAndFolders" xml:space="preserve">
+         <value>Fichiers et dossiers</value>
+     </data>
+     <data name="Commands" xml:space="preserve">
+         <value>Commandes</value>
+     </data>
 </root>

--- a/BlueAir/Properties/Resources.fy.resx
+++ b/BlueAir/Properties/Resources.fy.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} Download Agent</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Foarnaamste</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Bestannen en mappen</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Kommando&apos;s</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.ga.resx
+++ b/BlueAir/Properties/Resources.ga.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} Gníomhaire íoslódála</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Priomh</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Comhaid agus fillteáin</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Ord</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.gd.resx
+++ b/BlueAir/Properties/Resources.gd.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} luchdachadh sìos àidseant</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Prìomh</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Faidhlichean agus pasganan</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Òrdughan</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.gl.resx
+++ b/BlueAir/Properties/Resources.gl.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} axente de descarga</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Principal</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Arquivos e cartafoles</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Comandos</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.gu.resx
+++ b/BlueAir/Properties/Resources.gu.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} એજન્ટ ડાઉનલોડ કરો</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>મુખ્ય</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>ફાઇલો અને ફોલ્ડર્સ</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>આદેશો</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.ha.resx
+++ b/BlueAir/Properties/Resources.ha.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} Wakilin Download</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Babba</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Fayiloli da manyan fayiloli</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Umurni</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.haw.resx
+++ b/BlueAir/Properties/Resources.haw.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} Agent Agent</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Nui</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Nā faila a me nā folder</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Kauoha</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.he.resx
+++ b/BlueAir/Properties/Resources.he.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} סוכן הורדה</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>רָאשִׁי</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>קבצים ותיקיות</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>פקודות</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.hi.resx
+++ b/BlueAir/Properties/Resources.hi.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} डाउनलोड एजेंट</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>मुख्य</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>फ़ाइलें और फ़ोल्डर</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>आदेश</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.hr.resx
+++ b/BlueAir/Properties/Resources.hr.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} preuzmi agent</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Glavni</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Datoteke i mape</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Naredbe</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.hu.resx
+++ b/BlueAir/Properties/Resources.hu.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_Name} letöltési ügynök</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Fő</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Fájlok és mappák</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Parancsolat</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.hy.resx
+++ b/BlueAir/Properties/Resources.hy.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} Ներբեռնեք գործակալը</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Գլխավոր</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Ֆայլեր եւ պանակներ</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Հրամաններ</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.id.resx
+++ b/BlueAir/Properties/Resources.id.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} agen unduh</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Utama</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>File dan folder</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Perintah</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.ig.resx
+++ b/BlueAir/Properties/Resources.ig.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} Nchọpụta</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Keisi</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Faịlụ na folda</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Iwu</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.is.resx
+++ b/BlueAir/Properties/Resources.is.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} Sækja umboðsmann</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Aðal</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Skrár og möppur</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Skipanir</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.it.resx
+++ b/BlueAir/Properties/Resources.it.resx
@@ -159,4 +159,13 @@
     <data name="AgentFileDesc" xml:space="preserve">
          <value>Agente di download di {App_name}</value>
      </data>
+<data name="Main" xml:space="preserve">
+    <value>Principale</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>File e cartelle</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Comandi</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.ja.resx
+++ b/BlueAir/Properties/Resources.ja.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{app_name}ダウンロードエージェント</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>主要</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>ファイルとフォルダー</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>コマンド</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.ka.resx
+++ b/BlueAir/Properties/Resources.ka.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} ჩამოტვირთეთ აგენტი</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>მთავარი</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>ფაილები და საქაღალდეები</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>ბრძანებები</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.kk.resx
+++ b/BlueAir/Properties/Resources.kk.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name}} Агент жүктеу</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Басты</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Файлдар мен қалталар</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Пәрмендер</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.km.resx
+++ b/BlueAir/Properties/Resources.km.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{app__name} ទាញទាញយក</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>សមខាន់</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>ឯកសារនិងថតឯកសារ</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>ការបញ្ជា</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.kn.resx
+++ b/BlueAir/Properties/Resources.kn.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} ಡೌನ್‌ಲೋಡ್ ಏಜೆಂಟ್</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>ಮುಖ್ಯವಾದ</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>ಫೈಲ್‌ಗಳು ಮತ್ತು ಫೋಲ್ಡರ್‌ಗಳು</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>ಆಜ್ಞೆಗಳು</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.ko.resx
+++ b/BlueAir/Properties/Resources.ko.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{app_name} 다운로드 에이전트</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>기본</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>파일 및 폴더</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>명령</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.ku.resx
+++ b/BlueAir/Properties/Resources.ku.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} Daxistina Agent</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Ser</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Pel û peldankan</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Fermanan</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.ky.resx
+++ b/BlueAir/Properties/Resources.ky.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} скачать агент</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Негизги</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Файлдар жана папкалар</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Буйруктары</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.lb.resx
+++ b/BlueAir/Properties/Resources.lb.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} Download Agent</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Haaptsäit</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Dateien an Ordner</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Commandéiert</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.lo.resx
+++ b/BlueAir/Properties/Resources.lo.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{APP_NAME} ຕົວແທນດາວໂຫລດ</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>ດິນຫຼັກ</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>ແຟ້ມແລະແຟ້ມ</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>ການຢຄໍາສັ່ງ</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.lt.resx
+++ b/BlueAir/Properties/Resources.lt.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} atsisiuntimo agentas</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Pagrindinis</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Failai ir aplankai</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Komandos</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.lv.resx
+++ b/BlueAir/Properties/Resources.lv.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} lejupielādes aģents</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Galvenais</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Faili un mapes</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Pavēles</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.mg.resx
+++ b/BlueAir/Properties/Resources.mg.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} Download Agent</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Main</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Files sy Folders</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>didy</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.mi.resx
+++ b/BlueAir/Properties/Resources.mi.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} download kaihoko</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Matua</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Kōnae me nga Kōpaki</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Whakahau</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.mk.resx
+++ b/BlueAir/Properties/Resources.mk.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{APP_NAME} Агент за преземање</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Главна</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Датотеки и папки</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Команди</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.ml.resx
+++ b/BlueAir/Properties/Resources.ml.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} ഡൗൺലോഡ് ഏജന്റ്</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>പധാനമായ</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>ഫയലുകളും ഫോൾഡറുകളും</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>കമാൻഡുകൾ</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.mn.resx
+++ b/BlueAir/Properties/Resources.mn.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_Name} Татаж авах агент</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Гол зүйл</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Файл, хавтсыг</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Тушаал ач</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.mr.resx
+++ b/BlueAir/Properties/Resources.mr.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{अ‍ॅप_नाव} डाउनलोड एजंट</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>मुख्य</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>फायली आणि फोल्डर्स</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>आज्ञा</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.ms.resx
+++ b/BlueAir/Properties/Resources.ms.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} ejen muat turun</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Utama</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Fail dan folder</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Perintah</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.mt.resx
+++ b/BlueAir/Properties/Resources.mt.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} aġent ta &apos;tniżżil</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Prinċipali</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Fajls u folders</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Kmandi</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.my.resx
+++ b/BlueAir/Properties/Resources.my.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{app_name} ကိုဒေါင်းလုပ်လုပ်ပါ</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>အဓိက</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>ဖိုင်များနှင့်ဖိုင်တွဲများ</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>အမိန့်</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.ne.resx
+++ b/BlueAir/Properties/Resources.ne.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_mnam} डाउनलोड एजेन्ट</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>मूख्य</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>फाईलहरू र फोल्डरहरू</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>कमाण्त्व</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.nl.resx
+++ b/BlueAir/Properties/Resources.nl.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_Name} Download Agent</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Voornaamst</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Bestanden en mappen</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Opdrachten</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.no.resx
+++ b/BlueAir/Properties/Resources.no.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} nedlastingsagent</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Hoved</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Filer og mapper</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Kommandoer</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.or.resx
+++ b/BlueAir/Properties/Resources.or.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} lown ଡାଉନଲୋଡ୍ ଏଜେଣ୍ଟ |</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>ମୁଖ୍ୟ</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>ଫାଇଲ୍ ଏବଂ ଫୋଲ୍ଡରଗୁଡ଼ିକ |</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>ନିର୍ଦ୍ଦେଶଗୁଡ଼ିକ</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.pa.resx
+++ b/BlueAir/Properties/Resources.pa.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>Apply ਐਪਸ_ਨੇਮ} ਡਾਉਨਲੋਡ ਏਜੰਟ</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>ਮੁੱਖ</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>ਫਾਈਲਾਂ ਅਤੇ ਫੋਲਡਰ</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>ਕਮਾਂਡਾਂ</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.pl.resx
+++ b/BlueAir/Properties/Resources.pl.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} agent pobierania</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Główny</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Pliki i foldery</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Polecenia</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.ps.resx
+++ b/BlueAir/Properties/Resources.ps.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>mpp اپ_ نوم} ډاونلوډ اجنټ</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>اصلي</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>فایلونه او فولډرونه</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>حکمونه</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.pt.resx
+++ b/BlueAir/Properties/Resources.pt.resx
@@ -161,4 +161,13 @@
          <value>{App_name} Agente de download</value>
      </data>
 
+<data name="Main" xml:space="preserve">
+    <value>Principal</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Arquivos e pastas</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Comandos</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.resx
+++ b/BlueAir/Properties/Resources.resx
@@ -159,4 +159,13 @@
     <data name="AgentFileDesc" xml:space="preserve">
         <value>{App_name} Download Agent</value>
     </data>
+    <data name="Main" xml:space="preserve">
+        <value>Main</value>
+    </data>
+    <data name="FilesAndFolders" xml:space="preserve">
+        <value>Files and Folders</value>
+    </data>
+    <data name="Commands" xml:space="preserve">
+        <value>Commands</value>
+    </data>
 </root>

--- a/BlueAir/Properties/Resources.ro.resx
+++ b/BlueAir/Properties/Resources.ro.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} agent de descărcare</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Principal</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Fișiere și foldere</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Comenzi</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.ru.resx
+++ b/BlueAir/Properties/Resources.ru.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} Скачать агент</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Основной</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Файлы и папки</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Команды</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.sd.resx
+++ b/BlueAir/Properties/Resources.sd.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{ايپ_ نالو} ڊائون لوڊ ايجنٽ</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>اهم</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>فائلون ۽ فولڊر</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>حڪم ڏنل</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.si.resx
+++ b/BlueAir/Properties/Resources.si.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} බාගත කරන්න නියෝජිත</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>ප්රධාන</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>ලිපිගොනු සහ ෆෝල්ඩර</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>විධාන</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.sk.resx
+++ b/BlueAir/Properties/Resources.sk.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} Agent na stiahnutie</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Hlavná</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Súbory a priečinky</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Príkazy</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.sl.resx
+++ b/BlueAir/Properties/Resources.sl.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} Prenos agenta</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Glavno</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Datoteke in mape</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Ukazi</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.sn.resx
+++ b/BlueAir/Properties/Resources.sn.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} kurodha mumiririri</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Main</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Mafaera uye mafolda</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Mirairo</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.so.resx
+++ b/BlueAir/Properties/Resources.so.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} soo deg deg wakiil</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Muhiimsan</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Feylasha iyo faylka</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Amrid amar</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.sq.resx
+++ b/BlueAir/Properties/Resources.sq.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} agjent i shkarkimit</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Kryesor</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Skedarë dhe dosje</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Komandë</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.sr.resx
+++ b/BlueAir/Properties/Resources.sr.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{Апп_наме} Агент за преузимање</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Главни</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Датотеке и мапе</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Команде</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.su.resx
+++ b/BlueAir/Properties/Resources.su.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} Download agén</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Utama</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>File sareng polder</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Paréntah</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.sv.resx
+++ b/BlueAir/Properties/Resources.sv.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} nedladdningsagent</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Huvudsaklig</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Filer och mappar</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Kommandon</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.sw.resx
+++ b/BlueAir/Properties/Resources.sw.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} Wakala wa kupakua</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Kuu</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Faili na folda</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Amri</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.ta.resx
+++ b/BlueAir/Properties/Resources.ta.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} பதிவிறக்க முகவர்</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>முக்கிய</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>கோப்புகள் மற்றும் கோப்புறைகள்</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>கட்டளைகள்</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.te.resx
+++ b/BlueAir/Properties/Resources.te.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} డౌన్‌లోడ్ ఏజెంట్</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>ప్రధాన</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>ఫైల్స్ మరియు ఫోల్డర్లు</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>ఆదేశాలు</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.tg.resx
+++ b/BlueAir/Properties/Resources.tg.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} Download Download Download</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Асосӣ</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Файлҳо ва ҷузвдонҳо</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Фармонҳо</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.th.resx
+++ b/BlueAir/Properties/Resources.th.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{app_name} download agent</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>หลัก</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>ไฟล์และโฟลเดอร์</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>คำสั่ง</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.tr.resx
+++ b/BlueAir/Properties/Resources.tr.resx
@@ -23,10 +23,10 @@
         <value>Bir {app_name} dosyası seçiniz...</value>
     </data>
     <data name="CommandNoMobileInfo" xml:space="preserve">
-        <value>NOT: Bu özellik mobil platformlarda ve programalrın komutları çalıştırmasına izin vermeyen platformlarda çalışmaz.</value>
+        <value>NOT: Bu özellik mobil platformlarda ve programların komutları çalıştırmasına izin vermeyen platformlarda çalışmaz.</value>
     </data>
     <data name="ShowHideOutput" xml:space="preserve">
-        <value>Çıkılı Göster/Gizle</value>
+        <value>Çıkışı Göster/Gizle</value>
     </data>
     <data name="Downloader" xml:space="preserve">
         <value>İndirici</value>
@@ -68,7 +68,7 @@
         <value>Yeni Klasör...</value>
     </data>
     <data name="NewFile" xml:space="preserve">
-        <value>yeni Dosya...</value>
+        <value>Yeni Dosya...</value>
     </data>
     <data name="RemoveSelectedDO" xml:space="preserve">
         <value>Seçileni Sil...</value>
@@ -137,7 +137,7 @@
         <value>Lisans</value>
     </data>
     <data name="AboutTechnologies" xml:space="preserve">
-        <value>KUulanılan Teknolojiler:</value>
+        <value>Kulanılan Teknolojiler:</value>
     </data>
     <data name="SaveAFile" xml:space="preserve">
         <value>Bir {app_name} dosaysını kaydet...</value>
@@ -150,5 +150,14 @@
     </data>
     <data name="AgentFileDesc" xml:space="preserve">
         <value>{App_name} İndirici</value>
+    </data>
+    <data name="Commands" xml:space="preserve">
+        <value>Komutlar</value>
+    </data>
+    <data name="FilesAndFolders" xml:space="preserve">
+        <value>Dosyalar ve Klasörler</value>
+    </data>
+    <data name="Main" xml:space="preserve">
+        <value>Genel</value>
     </data>
 </root>

--- a/BlueAir/Properties/Resources.ug.resx
+++ b/BlueAir/Properties/Resources.ug.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} چۈشۈرۈش ۋاكالەتچىسى</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Main</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>ھۆججەت ۋە ھۆججەت قىسقۇچلار</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>بۇيرۇق</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.uk.resx
+++ b/BlueAir/Properties/Resources.uk.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} Агент Завантажити</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Головний</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Файли та папки</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Командування</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.ur.resx
+++ b/BlueAir/Properties/Resources.ur.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{app_name} ڈاؤن لوڈ ایجنٹ</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>مرکزی</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>فائلیں اور فولڈر</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>احکامات</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.uz.resx
+++ b/BlueAir/Properties/Resources.uz.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} yuklab olish bo&apos;yicha agent</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Asosiy</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Fayllar va papkalar</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Buyruqlar</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.vi.resx
+++ b/BlueAir/Properties/Resources.vi.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} Tác nhân tải xuống</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Chủ yếu</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Tập tin và thư mục</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Lệnh</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.xh.resx
+++ b/BlueAir/Properties/Resources.xh.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{Igama_gama} Khuphela iarhente</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Eyona nto iphambili</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Iifayile kunye neefolda</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Imiyalelo</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.yi.resx
+++ b/BlueAir/Properties/Resources.yi.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{אַפּ_נאַמע} אָפּלאָדירן אַגענט</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>גרויס</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>טעקעס און פאָלדערס</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>קאַמאַנדז</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.yo.resx
+++ b/BlueAir/Properties/Resources.yo.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name {Oluranlọwọ</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>Akọkọ</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Awọn faili ati Awọn folda</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Awọn pipaṣẹ</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.zh-Hans-TW.resx
+++ b/BlueAir/Properties/Resources.zh-Hans-TW.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{app_name}下載代理</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>主要的</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>文件和文件夾</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>命令</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.zh.resx
+++ b/BlueAir/Properties/Resources.zh.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{app_name}下载代理</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>主要的</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>文件和文件夹</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>命令</value>
+</data>
 </root>

--- a/BlueAir/Properties/Resources.zu.resx
+++ b/BlueAir/Properties/Resources.zu.resx
@@ -158,4 +158,13 @@
 <data name="AgentFileDesc" xml:space="preserve">
     <value>{App_name} landa i-ejenti</value>
 </data>
+<data name="Main" xml:space="preserve">
+    <value>-Namandla</value>
+</data>
+<data name="FilesAndFolders" xml:space="preserve">
+    <value>Amafayela namafolda</value>
+</data>
+<data name="Commands" xml:space="preserve">
+    <value>Imiyalo</value>
+</data>
 </root>

--- a/BlueAir/Views/MainView.axaml
+++ b/BlueAir/Views/MainView.axaml
@@ -47,7 +47,7 @@
                 </StackPanel>
                 <ScrollViewer Margin="10">
                     <StackPanel Orientation="Vertical" Spacing="10">
-                        <TextBlock Text="Main" FontSize="17.5" FontWeight="Bold" />
+                        <TextBlock Text="{x:Static blueAir:Resources.Main}" FontSize="17.5" FontWeight="Bold" />
                         <Border BorderThickness="2" CornerRadius="10" BorderBrush="#80808080">
                             <StackPanel Orientation="Vertical" Spacing="10" Margin="10">
                                 <DockPanel LastChildFill="True">
@@ -70,7 +70,7 @@
                                 </StackPanel>
                             </StackPanel>
                         </Border>
-                        <TextBlock Text="Commands" FontSize="17.5" FontWeight="Bold"
+                        <TextBlock Text="{x:Static blueAir:Resources.Commands}" FontSize="17.5" FontWeight="Bold"
                                    IsVisible="{CompiledBinding #RunCommandsBeforeAfter.IsChecked}"
                                    IsEnabled="{CompiledBinding #RunCommandsBeforeAfter.IsChecked}" />
                         <Border BorderThickness="2" CornerRadius="10" BorderBrush="#80808080"
@@ -102,7 +102,8 @@
                                 <TextBlock Text="{x:Static blueAir:Resources.CommandNoMobileInfo}" />
                             </StackPanel>
                         </Border>
-                        <TextBlock Text="Files and Folders" FontSize="17.5" FontWeight="Bold" />
+                        <TextBlock Text="{x:Static blueAir:Resources.FilesAndFolders}" FontSize="17.5"
+                                   FontWeight="Bold" />
                         <Border BorderThickness="2" CornerRadius="10" BorderBrush="#80808080">
                             <StackPanel Orientation="Vertical" Spacing="10" Margin="10">
                                 <WrapPanel HorizontalAlignment="Center">
@@ -172,9 +173,9 @@
                         <ToggleButton Name="UseSystemColor" IsCheckedChanged="UseSystemColorCheckedChanged">
                             <Panel>
                                 <TextBlock Text="{x:Static blueAir:Resources.UseDefaultColor}"
-                                           IsVisible="{CompiledBinding !#UseSystemColor.IsChecked}" />
-                                <TextBlock Text="{x:Static blueAir:Resources.UseColor}"
                                            IsVisible="{CompiledBinding #UseSystemColor.IsChecked}" />
+                                <TextBlock Text="{x:Static blueAir:Resources.UseColor}"
+                                           IsVisible="{CompiledBinding !#UseSystemColor.IsChecked}" />
                             </Panel>
                         </ToggleButton>
                         <ColorPicker Name="AccentColor" IsVisible="{CompiledBinding #UseSystemColor.IsChecked}"
@@ -201,7 +202,8 @@
                     </DockPanel>
                     <Separator />
                     <DockPanel LastChildFill="True">
-                        <TextBlock Text="{x:Static blueAir:Resources.VariablesTitle}" FontSize="17.5" FontWeight="Bold" />
+                        <TextBlock Text="{x:Static blueAir:Resources.VariablesTitle}" FontSize="17.5" FontWeight="Bold"
+                                   DockPanel.Dock="Top" Margin="0 0 0 5" />
                         <ScrollViewer>
                             <StackPanel Orientation="Vertical" Spacing="5" Name="VariableList" MinHeight="100" />
                         </ScrollViewer>

--- a/BlueAir/Views/MainView.axaml.cs
+++ b/BlueAir/Views/MainView.axaml.cs
@@ -151,7 +151,7 @@ public partial class MainView : UserControl
         if (BlueAir.CustomFolders != null && BlueAir.CustomFolders.Length > 0)
             foreach (var env_var in BlueAir.CustomFolders)
             {
-                DockPanel dockPanel = new() { LastChildFill = true };
+                DockPanel dockPanel = new() { LastChildFill = true, Margin = new Thickness(20, 5) };
                 TextBlock varName = new()
                     { VerticalAlignment = VerticalAlignment.Center, Text = env_var.SpecialFolder + ":" };
                 DockPanel.SetDock(varName, Dock.Left);
@@ -159,12 +159,12 @@ public partial class MainView : UserControl
                 var browse = new Button { Content = "..." };
                 DockPanel.SetDock(browse, Dock.Right);
                 dockPanel.Children.Add(browse);
-                var varValue = new TextBox { Text = env_var.GetPath };
+                var varValue = new TextBox { Text = env_var.GetPath, Margin = new Thickness(5, 0) };
                 varValue.TextChanged += (_, _) => env_var.NewPath = varValue.Text;
                 dockPanel.Children.Add(varValue);
                 browse.Click += async (_, _) =>
                 {
-                    await Task.Run(async () =>
+                    await Dispatcher.UIThread.InvokeAsync(async () =>
                     {
                         if (Parent is not TopLevel topLevel) return;
                         if (!topLevel.StorageProvider.CanPickFolder) return;
@@ -204,10 +204,7 @@ public partial class MainView : UserControl
                    Assembly.GetExecutingAssembly() is { } ass
                    && ass.GetName() is { } name
                    && name.Version != null
-                       ? "" + (name.Version.Major > 0 ? name.Version.Major : "") +
-                         (name.Version.Minor > 0 ? "." + name.Version.Minor : "") +
-                         (name.Version.Build > 0 ? "." + name.Version.Build : "") +
-                         (name.Version.Revision > 0 ? "." + name.Version.Revision : "")
+                       ? name.Version.ToString()
                        : "?"
                );
     }


### PR DESCRIPTION
Contains fixes:

 - Custom variables' menu is positioned weird.
 - Translations for some titles were missing.
 - CLI is also desktop cross-platform and does not upload specific builds.
 - Versions are missing.
 - Changing a custom variable from "..." button crashes app.
 - Trimmed & single file artifacts for CLI

## Trim vs. AOT

Currently, both are the same except trimmed apps are CIL still and NativeAOT builds are native programs that don't rely on a runtime. Personally, there is no huge performance difference between each other for now. Despite including the runtime (with `--self-contained` argument while building) trimmed build should've bigger than AOT build bu turns out it is somehow slightly smaller so I decided to use self-contained trimmed single-file approach instead of NativeAOT.